### PR TITLE
Ignore Wwise meta files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ Assets/WwiseSettings.xml.meta
 .DS_Store
 ph.meta
 ph
+/Assets/Wwise/**/*.meta
+Assets/Wwise.meta


### PR DESCRIPTION
Wwise meta files persist in changeless with constant alterations unique to workstations.

If this continues, we'll likely run into multitudes of conflicts revolving these files.

Originally they we're included since the Unity guideline is to include all meta files, however it's become clear that wwise will forever modify these files, which will lead to merging issues later on.

Adds:
``` gitignore
# Ignores meta files within the wwise package
/Assets/Wwise/**/*.meta 

# Ignores meta for the wwise package
/Assets/Wwise.meta
```